### PR TITLE
rm: watchtower端口

### DIFF
--- a/tm.sh
+++ b/tm.sh
@@ -111,7 +111,7 @@ container_build(){
   docker run -d --name $NAME --restart=unless-stopped traffmonetizer/cli_v2:$ARCH start accept --token "$TMTOKEN" >/dev/null 2>&1
 
   # 创建 Towerwatch
-  [[ ! $(docker ps -a) =~ watchtower ]] && yellow " Create TowerWatch.\n " && docker run -d --name watchtower --restart=always -p 2095:8080 -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --cleanup >/dev/null 2>&1
+  [[ ! $(docker ps -a) =~ watchtower ]] && yellow " Create TowerWatch.\n " && docker run -d --name watchtower --restart=always -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --cleanup >/dev/null 2>&1
 }
 
 # 显示结果


### PR DESCRIPTION
查询文档（https://containrrr.dev/watchtower/http-api-mode/）得知这个端口暴露仅用于HTTP API。如果只用于本地更新则不需要这个端口